### PR TITLE
Implemented idea 2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nbproject


### PR DESCRIPTION
This is take 2 on the implementation.

When a URL is set, it should work exactly the same behavior and configuration.
 - Open a strean in init, write (as much as needed) in export and close it on __destruct.
 - When no URL is set, It will allow the setting of a pre-opened stream (that will not be closed in this component) to be used for logging. This is mainly to be used for 

Possible improvements would be change is to have this split in 2 concrete classes, coming in a new PR.
