### PR TITLE
Idea 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nbproject

--- a/src/CliTarget.php
+++ b/src/CliTarget.php
@@ -24,7 +24,6 @@ class CliTarget extends BaseTarget
      * Already open writable stream to send logs entries to.
      *
      * Recommended for use in CLI context for STDOUT and STDERR.
-     * Property 'url' takes precedence.
      *
      * @var resource
      */

--- a/src/CliTarget.php
+++ b/src/CliTarget.php
@@ -1,0 +1,91 @@
+<?php
+namespace codemix\streamlog;
+
+use yii\log\Target as BaseTarget;
+use yii\base\InvalidConfigException;
+
+/**
+ * A log target for pre-opened stream resources.
+ *
+ * Recommended use is against STDERR or STDOUT in PHP-CLI applications.
+ *
+ * @property-write resource $fp Pre-open writable stream resource.
+ */
+class CliTarget extends BaseTarget
+{
+
+    /**
+     * @var string|null a string that should replace all newline characters in a log message.
+     * Default ist `null` for no replacement.
+     */
+    public $replaceNewline;
+
+    /**
+     * Already open writable stream to send logs entries to.
+     *
+     * Recommended for use in CLI context for STDOUT and STDERR.
+     * Property 'url' takes precedence.
+     *
+     * @var resource
+     */
+    private $_fp = null;
+
+
+    /**
+     * The writable stream resource instance managed by the target.
+     *
+     * @return resource
+     */
+    protected function getFp() {
+        return $this->_fp;
+    }
+
+    /**
+     * Mutator of `fp` property.
+     *
+     * @param resource $fp
+     * @throws InvalidConfigException
+     */
+    public function setFp(resource $fp) {
+        $metadata = stream_get_meta_data($fp);
+        if ($metadata['mode'] != 'w') {
+            throw new InvalidConfigException("Non-writable stream provided!");
+        }
+        $this->_fp = $fp;
+    }
+
+    /**
+     * Validates class configuration.
+     *
+     * Ensures that a writable stream is present in the system, based on config.
+     *
+     * @throws InvalidConfigException When unable to aquire a writable stream.
+     */
+    public function init() {
+        // We should have a writable stream available at this point.
+        if (empty($this->_fp)) {
+            throw new InvalidConfigException("No writable stream provided! Set `fp` property.");
+        }
+    }
+
+    /**
+     * Writes a log message to the given target URL.
+     */
+    public function export()
+    {
+        $text = implode("\n", array_map([$this, 'formatMessage'], $this->messages)) . "\n";
+        fwrite($this->_fp, $text);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function formatMessage($message)
+    {
+        $text = parent::formatMessage($message);
+        if ($this->replaceNewline !== null) {
+            $text = str_replace("\n", $this->replaceNewline, $text);
+        }
+        return $text;
+    }
+}

--- a/src/Target.php
+++ b/src/Target.php
@@ -1,34 +1,17 @@
 <?php
 namespace codemix\streamlog;
 
-use yii\log\Target as BaseTarget;
 use yii\base\InvalidConfigException;
 
 /**
  * A log target for streams in URL format.
  */
-class Target extends BaseTarget
+class Target extends CliTarget
 {
     /**
      * @var string the URL to use. See http://php.net/manual/en/wrappers.php for details.
      */
     public $url;
-
-    /**
-     * Already open writable stream to send logs entries to.
-     *
-     * Recommended for use in CLI context for STDOUT and STDERR.
-     * Property 'url' takes precedence.
-     *
-     * @var resource
-     */
-    public $fp = null;
-
-    /**
-     * @var string|null a string that should replace all newline characters in a log message.
-     * Default ist `null` for no replacement.
-     */
-    public $replaceNewline;
 
     /**
      * Validates class configuration.
@@ -38,51 +21,19 @@ class Target extends BaseTarget
      * @throws InvalidConfigException When unable to aquire a writable stream.
      */
     public function init() {
-        // URL overwrites the passed on stream and is being explicitly opened.
-        if (!empty($this->url) && ($this->fp = @fopen($this->url, 'w')) !== false) {
-            return;
+        if (empty($this->url)) {
+            throw new InvalidConfigException("No url configured.");
         }
-
-        // We should have a writable stream passed in.
-        if (!empty($this->fp)
-            && is_resource($this->fp)
-            && ($metadata = stream_get_meta_data($this->fp))
-            && $metadata['mode'] == 'w'
-        ) {
-            return;
+        if (($fp = @fopen($this->url, 'w')) === false) {
+            throw new InvalidConfigException("Unable to append to '{$this->url}'");
         }
-
-        throw new InvalidConfigException("No writable stream aquired! Set `url` or `fp` properties.");
-    }
-
-    /**
-     * Writes a log message to the given target URL.
-     */
-    public function export()
-    {
-        $callback = [$this, 'formatMessage'];
-        $text = implode("\n", array_map($callback, $this->messages)) . "\n";
-        fwrite($this->fp, $text);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function formatMessage($message)
-    {
-        $text = parent::formatMessage($message);
-        if ($this->replaceNewline !== null) {
-            $text = str_replace("\n", $this->replaceNewline, $text);
-        }
-        return $text;
+        $this->setFp($fp);
     }
 
     /**
      * Clean-up streams that we've opened.
      */
     public function __destruct() {
-        if (!empty($this->url) && $this->fp) {
-            fclose($this->fp);
-        }
+        fclose($this->getFp());
     }
 }


### PR DESCRIPTION
Based on Idea 2.
This should make everything fully decoupled and with minimum conditionals.

There is the base CliTarget base class that expects a writable resource to be injected and used (not cleared). It is recommended for the STDERR and STDOUT.

The target class extends the CliTarget one and based on the configured URL, injects a writable stream to be used. It clears the stream when it's not in use (on __destruct).